### PR TITLE
Fixing compilation on OpenBSD systems

### DIFF
--- a/LDAP.cabal
+++ b/LDAP.cabal
@@ -41,7 +41,10 @@ Library
 
   GHC-Options: -O2
   -- CC-Options: -Iglue
-  CC-Options: -DLDAP_DEPRECATED=1
+  if os(openbsd)
+    CC-Options: -DLDAP_X_PROXY_AUTHZ_FAILURE=LDAP_PROXY_AUTHZ_FAILURE
+  else
+    CC-Options: -DLDAP_DEPRECATED=1
   Extensions: ForeignFunctionInterface, TypeSynonymInstances,
               EmptyDataDecls, ScopedTypeVariables, CPP
 
@@ -52,7 +55,10 @@ Executable runtests
     Buildable: False
   Extra-Libraries: ldap
   Main-Is: runtests.hs
-  CC-Options: -DLDAP_DEPRECATED=1
+  if os(openbsd)
+    CC-Options: -DLDAP_X_PROXY_AUTHZ_FAILURE=LDAP_PROXY_AUTHZ_FAILURE
+  else
+    CC-Options: -DLDAP_DEPRECATED=1
   Extensions: ForeignFunctionInterface, TypeSynonymInstances,
               EmptyDataDecls, ScopedTypeVariables, CPP
   Hs-Source-Dirs: testsrc, .


### PR DESCRIPTION
Hi,

```
I wrote a patch to fix the compilation of ldap-haskell on OpenBSD systems. The problem is that those folks are still using the OpenLDAP libs in version 2.3 (while current is 2.4) therefore one macro differs. This patch fixes the problem for OpenBSD and of course won't change a thing on Linux systems and others who use a more recent version of the ldap libs.

And by the way thank you for providing this LDAP binding, it's pretty usefull to me.
```

Ciao,
    Julien Dessaux
